### PR TITLE
Use correct redis env vars in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       # Name of the database subscan will connect to and use
       # this db must exist
       MYSQL_DB: 'subscan'
-      REDIS_ADDR: redis:6379
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
       CHAIN_WS_ENDPOINT: 'ws://host.docker.internal:9944'
       # the types file used for the chain as:
       # configs/source/{NETWORK_NODE}.json


### PR DESCRIPTION
The correct vars are `REDIS_HOST` and `REDIS_PORT`, not `REDIS_ADDR`. It's wrong (and misleading) in the docker compose file.