### PR TITLE
CSUB-605: Set REDIS_INSECURE=true for local testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       MYSQL_DB: 'subscan'
       REDIS_HOST: redis
       REDIS_PORT: 6379
+      REDIS_INSECURE: 'true'
       CHAIN_WS_ENDPOINT: 'ws://host.docker.internal:9944'
       # the types file used for the chain as:
       # configs/source/{NETWORK_NODE}.json


### PR DESCRIPTION
Subscan was able to process 15000+ blocks in about 2 minutes and I am now able to see payout charts in the dashboard.