### PR TITLE
CSUB-855: Update timeouts in Subscan Websocket connections

### DIFF
--- a/internal/observer/observer.go
+++ b/internal/observer/observer.go
@@ -26,7 +26,7 @@ func Run(dt string) {
 	for {
 		switch dt {
 		case "substrate":
-			conn := &recws.RecConn{KeepAliveTimeout: 10 * time.Second, WriteTimeout: time.Second * 10, ReadTimeout: 60 * time.Second}
+			conn := &recws.RecConn{KeepAliveTimeout: 60 * time.Second, WriteTimeout: time.Second * 60, ReadTimeout: 60 * time.Second}
 			conn.Dial(util.WSEndPoint, nil)
 			go srv.Subscribe(conn, stop)
 			slog.Debug("Connected to substrate node")

--- a/internal/observer/observer.go
+++ b/internal/observer/observer.go
@@ -26,7 +26,7 @@ func Run(dt string) {
 	for {
 		switch dt {
 		case "substrate":
-			conn := &recws.RecConn{KeepAliveTimeout: 5 * time.Second, WriteTimeout: time.Second * 5, ReadTimeout: 60 * time.Second}
+			conn := &recws.RecConn{KeepAliveTimeout: 10 * time.Second, WriteTimeout: time.Second * 10, ReadTimeout: 60 * time.Second}
 			conn.Dial(util.WSEndPoint, nil)
 			go srv.Subscribe(conn, stop)
 			slog.Debug("Connected to substrate node")


### PR DESCRIPTION
Subscan’s websocket connections have relatively short timeouts (5 seconds for some). Increasing these should improve stability.

The values for `KeepAliveTimeout` and `WriteTimeout` were brought up to 60 seconds to match the value of `ReadTimeout`. 